### PR TITLE
extra libraries type can be configured

### DIFF
--- a/recipes/attribute_driven_domain.rb
+++ b/recipes/attribute_driven_domain.rb
@@ -73,14 +73,14 @@ node['glassfish']['domains'].each_pair do |domain_key, definition|
   end
 
   if definition['extra_libraries']
-    definition['extra_libraries'].values.each do |value|
-      glassfish_library value do
+    definition['extra_libraries'].values.each do |config|
+      glassfish_library config['source'] do
         domain_name domain_key
         admin_port admin_port if admin_port
         username username if username
         password_file password_file if password_file
         secure secure if secure
-        library_type 'ext'
+        library_type (config['type'] || 'ext')
       end
     end
   end


### PR DESCRIPTION
I tried to add the postgresql-jdbc-driver as extra library. It didn't work because by default, extra libraries are uploaded as type `ext`. Thus the need to configure the type.

extra_libraries configuration must now look like this (with a source and a type key):

```
                              :extra_libraries => {
                                    :pg => {
                                        :source => 'http://search.maven.org/remotecontent?filepath=postgresql/postgresql/9.1-901-1.jdbc4/postgresql-9.1-901-1.jdbc4.jar',
                                        :type => 'common'
                                    }
                                },
```

Is that ok?
