### PR TITLE
Added mq_ensure_running resource to replace upstart checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v0.5.26:
 
+* Bug     : Added mq\_ensure\_running resource to replace upstart check which
+            was causing issues on IPv6 enabled hosts. ~ Jordan Hagan
+
 ## v0.5.24:
 * Bug     : Fix the `attribute_driven_domain` to avoid undeploying OSGi deployables every secodn run.
 * Change  : Append versions to the name of OSGi components rather than storing the version on the

--- a/providers/mq.rb
+++ b/providers/mq.rb
@@ -288,6 +288,11 @@ action :create do
   destinations.merge!(new_resource.queues)
   destinations.merge!(new_resource.topics)
 
+  glassfish_mq_ensure_running 'wait for initialization' do
+    host 'localhost'
+    port new_resource.port
+  end
+
   destinations.each_pair do |key, config|
     glassfish_mq_destination key do
       queue new_resource.queues.keys.include?(key)

--- a/providers/mq_ensure_running.rb
+++ b/providers/mq_ensure_running.rb
@@ -1,0 +1,38 @@
+#
+# Copyright Peter Donald
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "socket"
+
+action :run do
+  ruby_block "block_until_running" do
+    block do
+      count = 0
+      loop do
+        raise "OpenMQ broker never came online" if count > 50
+        begin
+          s = TCPSocket.new new_resource.host, new_resource.port
+          break
+        rescue Errno::ECONNREFUSED
+          Chef::Log.debug "OpenMQ broker not running, attempt #{count}"
+        ensure
+          s.close unless s.nil?
+        end
+        count += 1
+        sleep 1
+      end
+    end
+  end
+end

--- a/resources/mq_ensure_running.rb
+++ b/resources/mq_ensure_running.rb
@@ -1,0 +1,39 @@
+#
+# Copyright Peter Donald
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+=begin
+#<
+Ensures that a OpenMQ message broker instance has had a chance to finish starting before proceeding.
+
+@action run Block until the broker has come online.
+
+@section Examples
+
+    # Wait for OpenMQ broker to start
+    glassfish_mq_ensure_running "wait for broker" do
+      host "localhost"
+      port 7676
+    end
+#>
+=end
+
+actions :run
+default_action :run
+
+#<> @attribute host The host on which the broker runs.
+attribute :host, :kind_of => String
+#<> @attribute port The port on which the broker listens.
+attribute :port, :kind_of => Integer

--- a/templates/default/omq-upstart.conf.erb
+++ b/templates/default/omq-upstart.conf.erb
@@ -20,23 +20,3 @@ pre-start script
 end script
 
 exec su <%= node['glassfish']['user'] %> -c '<%= authbind_prefix %><%= omq_home %>/bin/imqbrokerd -vmargs "<%= @vmargs %>" -varhome <%= node['openmq']['var_home'] %> -javahome <%= node["java"]["java_home"] %> -name "<%= @resource.instance %>"'
-
-# Uglies to wait until the broker is actually up before completion of the 'start'
-post-start script
-  <% @listen_ports.sort.each do |listen_port| %>
-  while [ $(netstat -nl | grep -c '0.0.0.0:<%= listen_port %> ') -eq 0 ]
-  do
-    sleep 1
-  done
-  <% end %>
-end script
-
-# Uglies to wait until the broker is actually up before completion of the 'stop'
-post-stop script
-  <% @listen_ports.sort.each do |listen_port| %>
-  while [ $(netstat -nl | grep -c '0.0.0.0:<%= listen_port %> ') -ne 0 ]
-  do
-    sleep 1
-  done
-  <% end %>
-end script


### PR DESCRIPTION
Originally the upstart job blocked until the port had opened, this was
to ensure that the broker was online before other resources attempted to
access it. This causes a few issues when the box is running IPv6 due to
differences in the netstat output.

A more robust solution is to actually atempt to connect to the port
using a resource, and spin until it either comes online or times out.
The glassfish_mq_ensure_running resource implements this method.
