### PR TITLE
Fixed glassfish_domain template when used outside glassfish cookbook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v0.5.26:
 
+* Bug     : Fix for glassfish\_domain resource sourcing template from cookbook
+            where it is used.
+
 ## v0.5.24:
 * Bug     : Fix the `attribute_driven_domain` to avoid undeploying OSGi deployables every secodn run.
 * Change  : Append versions to the name of OSGi components rather than storing the version on the

--- a/providers/domain.rb
+++ b/providers/domain.rb
@@ -218,6 +218,7 @@ action :create do
 
   if new_resource.password_file
     template new_resource.password_file do
+      cookbook 'glassfish'
       only_if { new_resource.password }
       source "password.erb"
       owner node['glassfish']['user']


### PR DESCRIPTION
When called outside of the glassfish cookbook, the domain provider
attempts to source the `password.erb` file from the calling cookbook,
rather than the glassfish cookbook.
