### PR TITLE
Made keys for accessing user/pass when generating hash consistent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v0.5.26:
 
+* Bug     : Consistency fix for attributes used to generate password hash in
+            OpenMQ passwd file.
+
 ## v0.5.24:
 * Bug     : Fix the `attribute_driven_domain` to avoid undeploying OSGi deployables every secodn run.
 * Change  : Append versions to the name of OSGi components rather than storing the version on the

--- a/templates/default/passwd.erb
+++ b/templates/default/passwd.erb
@@ -8,7 +8,7 @@
    end
 
 %><% @users.sort.each do |username, config|
-  password_hash = Digest::MD5.hexdigest("#{username}:#{config[:password]}")
+  password_hash = Digest::MD5.hexdigest("#{username}:#{config['password']}")
   signed_password_hash = to_signed(password_hash.to_i(16)).to_s(16)
 %><%= username %>:<%= signed_password_hash %>:<%= config['group'] || 'user'%>:1
 <% end %>


### PR DESCRIPTION
This creates an issue when using the resource diretly, as in this case
the resource receives a Hash object. When using the resource from a node
attribute driven recipe the resource receives a Mash instead.

Fixes #9
