### PR TITLE
Allow other programs (like Logstash) to access the glassfish logs.

### DIFF
--- a/templates/default/glassfish-upstart.conf.erb
+++ b/templates/default/glassfish-upstart.conf.erb
@@ -15,7 +15,7 @@ setuid <%= @resource.system_user %>
 setgid <%= @resource.system_group %>
 respawn limit 15 5
 kill signal HUP
-umask 0077
+umask 0022
 
 <% config_dir = "#{node['glassfish']['domains_dir']}/#{@resource.domain_name}/config" %>
 pre-start script

--- a/templates/default/omq-upstart.conf.erb
+++ b/templates/default/omq-upstart.conf.erb
@@ -10,7 +10,7 @@ stop on runlevel [!2345]
 
 # Increase default timeout before killing (on stop) to 10 seconds
 kill timeout 10
-umask 0077
+umask 0022
 
 <% omq_home = "#{node['glassfish']['base_dir']}/mq" %>
 <% authbind_prefix = @authbind ? "/usr/bin/authbind --deep " : "" %>


### PR DESCRIPTION
The current config is too strict.Since i'm using Logstash to collect all my logs there was no other way then to open up the security a bit.
