### PR TITLE
Application libraries used during deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## v0.7.6 (Pending):
 * Enhance : Generate `asenv.conf` with correct values in case the asadmin command is used
             directly and not from the init scripts or using the generated script.
+* Enhance : Makes application library usage available for deployables stored in
+            ${com.sun.aas.instanceRootURI}/lib/applibs
 * Change  : Depend upon the `compat_resource` cookbook if present. This is required for
             Chef 12.5+ as chef client changed the resource API between 12.4 and 12.5.
             Change was inspired by Tero Pihlaja.

--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ used when there is not yet a resource defined in this cookbook for executing an 
 - admin_port: The port on which the web management console is bound. Defaults to <code>4848</code>.
 - system_user: The user that the domain executes as. Defaults to `node['glassfish']['user']` if unset. Defaults to <code>nil</code>.
 - system_group: The group that the domain executes as. Defaults to `node['glassfish']['group']` if unset. Defaults to <code>nil</code>.
+- libraries: Array of JAR file names deployed as applibs which are used by this deployable. Defaults to <code>[]</code>
 
 ## glassfish_domain
 

--- a/providers/deployable.rb
+++ b/providers/deployable.rb
@@ -130,6 +130,7 @@ action :deploy do
       command << '--properties' << encode_parameters(new_resource.properties) unless new_resource.properties.empty?
       command << "--virtualservers=#{new_resource.virtual_servers.join(',')}" unless new_resource.virtual_servers.empty?
       command << '--deploymentplan' << deployment_plan if deployment_plan
+      command << "--libraries=#{new_resource.libraries.join(',')}" unless new_resource.libraries.empty?
       command << a.target_artifact
 
       timeout 150

--- a/recipes/attribute_driven_domain.rb
+++ b/recipes/attribute_driven_domain.rb
@@ -791,6 +791,7 @@ gf_sort(node['glassfish']['domains']).each_pair do |domain_key, definition|
         properties configuration['properties'] if configuration['properties']
         descriptors configuration['descriptors'] if configuration['descriptors']
         lb_enabled configuration['lb_enabled'] if configuration['lb_enabled']
+        libraries configuration['libraries'] if configuration['libraries']
       end
       gf_sort(configuration['web_env_entries'] || {}).each_pair do |key, value|
         hash = value.is_a?(Hash) ? value : {'value' => value}

--- a/resources/deployable.rb
+++ b/resources/deployable.rb
@@ -34,6 +34,7 @@ attribute :precompile_jsp, :equal_to => [true, false, 'true', 'false'], :default
 attribute :async_replication, :equal_to => [true, false, 'true', 'false'], :default => true
 attribute :properties, :kind_of => Hash, :default => {}
 attribute :descriptors, :kind_of => Hash, :default => {}
+attribute :libraries, :kind_of => Array, :default => []
 
 #<> @attribute domain_name The name of the domain.
 attribute :domain_name, :kind_of => String, :required => true


### PR DESCRIPTION
JAR libraries installed as application libraries (`${com.sun.aas.instanceRootURI}/lib/applibs`) can be used independently by specific deployed applications. [Oracle Glassfish's asadmin reference guide](http://docs.oracle.com/cd/E26576_01/doc.312/e24938/deploy.htm#GSRFM00114) and the [Oracle Glassfish's application-specific classloading](https://docs.oracle.com/cd/E18930_01/html/821-2418/gatej.html) documentation has more on the topic.