### PR TITLE
Chef 12.5 compatibility issue's 'real' fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
             directly and not from the init scripts or using the generated script.
 * Change  : Depend upon the `compat_resource` cookbook if present. This is required for
             Chef 12.5+ as chef client changed the resource API between 12.4 and 12.5.
-            Change was inspired by Tero Pihlaja.
+            Change was inspired by Tero Pihlaja, fixed by David Lakatos.
 
 ## v0.7.4:
 * Change  : Added support for portbase in the domain creation command.

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version          '0.7.5'
 supports 'ubuntu'
 
 # Compat resource is required for 12.5+ as resource API changed between 12.4 and 12.5
-supports 'compat_resource'
+depends 'compat_resource'
 
 depends 'java'
 depends 'authbind'


### PR DESCRIPTION
in `metadata.rb`, `supports` doesn't solve the [problem](https://github.com/realityforge/chef-glassfish/issues/57#issuecomment-174354630), `depends` does