### PR TITLE
Update default_ream_confs to Glassfish 4 values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Enhance : Enables Glassfish instances defined in the domain attributes. Fixes #77.
             Submitted by David Lakatos.
 * Enhance : Add support for defining JMS Destinations. Submitted by James Walker.
-* Enhance : Add support for Payara 4.1.1.161. Submitted by James Walker.
+* Enhance : Add support for Payara 4.1.1.161. Submitted by Ian Caughley.
 * Bug     : Make sure thread pools that are not configured are correctly deleted.
             Fixes #88. Reported by David Lakatos.
 * Bug     : Fix directory permissions on archives directory. Fixes #80.
@@ -20,6 +20,7 @@
                 'deployables' => {
                         'managed' => false
                     },
+Change    : Updated login.conf for Glassfish 4. Submitted by Ian Caughley.
 
 ## v0.7.6:
 * Enhance : Generate `asenv.conf` with correct values in case the asadmin command is used

--- a/providers/domain.rb
+++ b/providers/domain.rb
@@ -95,9 +95,9 @@ def default_realm_confs
     'fileRealm' => 'com.sun.enterprise.security.auth.login.FileLoginModule',
     'ldapRealm' => 'com.sun.enterprise.security.auth.login.LDAPLoginModule',
     'solarisRealm' => 'com.sun.enterprise.security.auth.login.SolarisLoginModule',
-    'jdbcRealm' => 'com.sun.enterprise.security.auth.login.JDBCLoginModule',
-    'jdbcDigestRealm' => 'com.sun.enterprise.security.auth.login.JDBCDigestLoginModule',
-    'pamRealm' => 'com.sun.enterprise.security.auth.login.PamLoginModule',
+    'jdbcRealm' => 'com.sun.enterprise.security.ee.auth.login.JDBCLoginModule',
+    'jdbcDigestRealm' => 'com.sun.enterprise.security.ee.auth.login.JDBCDigestLoginModule',
+    'pamRealm' => 'com.sun.enterprise.security.ee.auth.login.PamLoginModule',
   }
 end
 

--- a/providers/domain.rb
+++ b/providers/domain.rb
@@ -91,14 +91,25 @@ def default_logging_properties
 end
 
 def default_realm_confs
-  {
+  common_confs = {
     'fileRealm' => 'com.sun.enterprise.security.auth.login.FileLoginModule',
     'ldapRealm' => 'com.sun.enterprise.security.auth.login.LDAPLoginModule',
     'solarisRealm' => 'com.sun.enterprise.security.auth.login.SolarisLoginModule',
-    'jdbcRealm' => 'com.sun.enterprise.security.ee.auth.login.JDBCLoginModule',
-    'jdbcDigestRealm' => 'com.sun.enterprise.security.ee.auth.login.JDBCDigestLoginModule',
-    'pamRealm' => 'com.sun.enterprise.security.ee.auth.login.PamLoginModule',
   }
+
+  if node['glassfish']['version'][0] == '4'
+    {
+      'jdbcRealm' => 'com.sun.enterprise.security.ee.auth.login.JDBCLoginModule',
+      'jdbcDigestRealm' => 'com.sun.enterprise.security.ee.auth.login.JDBCDigestLoginModule',
+      'pamRealm' => 'com.sun.enterprise.security.ee.auth.login.PamLoginModule',
+    }.merge common_confs
+  else
+    {
+      'jdbcRealm' => 'com.sun.enterprise.security.auth.login.JDBCLoginModule',
+      'jdbcDigestRealm' => 'com.sun.enterprise.security.auth.login.JDBCDigestLoginModule',
+      'pamRealm' => 'com.sun.enterprise.security.auth.login.PamLoginModule',
+    }.merge common_confs
+  end
 end
 
 def domain_dir_arg


### PR DESCRIPTION
Hiya. Do we even need to generate the login.conf in this way? Looks like it is created automatically to me.

NOTE: This change will break Glassfish 3. Is this still being supported? If so, I'll need to add a switch.