### PR TITLE
Only create the glassfish group if it doesn't already exist 

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,6 +63,7 @@ raise "glassfish.package_url not specified and unable to be derived. Please spec
 include_recipe 'java'
 
 group node['glassfish']['group'] do
+  not_if "getent group #{node['glassfish']['group']}"
 end
 
 user node['glassfish']['user'] do


### PR DESCRIPTION
Fixes #99 
Check to see if the group exists before trying to create it.