### PR TITLE
Support for the 171 release of Payara Server

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,3 +59,4 @@ default['glassfish']['package_urls']['payara']['4.1.1.161.1'] = 'https://s3-eu-w
 default['glassfish']['package_urls']['payara']['4.1.1.162'] = 'https://s3-eu-west-1.amazonaws.com/payara.co/Payara+Downloads/Payara+4.1.1.162/payara-4.1.1.162.zip'
 default['glassfish']['package_urls']['payara']['4.1.1.163'] = 'https://s3-eu-west-1.amazonaws.com/payara.co/Payara+Downloads/Payara+4.1.1.163/payara-4.1.1.163.zip'
 default['glassfish']['package_urls']['payara']['4.1.1.164'] = 'https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/Payara+4.1.1.164/payara-4.1.1.164.zip'
+default['glassfish']['package_urls']['payara']['4.1.1.171'] = 'https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/Payara+4.1.1.171.0.1/payara-4.1.1.171.0.1.zip'


### PR DESCRIPTION
There was a minor patch which necessitated the `.0.1` suffix since the release was already on Maven Central at that point.