### PR TITLE
Add asadmin execution rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.2.8:
+* Fix : Add asadmin execution rights to `node['glassfish']['user']` and `node['glassfish']['group']`
+
 ## v1.2.7:
 * Enhance : Add support for Payara 5.2021.10
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Peter Donald'
 maintainer_email 'peter@realityforge.org'
 license 'Apache-2.0'
 description 'Installs/Configures GlassFish Application Server'
-version '1.2.7'
+version '1.2.8'
 chef_version '>= 13.0'
 
 issues_url 'https://github.com/realityforge/chef-glassfish'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -70,6 +70,14 @@ end
 
 node.override['glassfish']['install_dir'] = a.target_directory
 
+unless node.windows?
+  file "#{node['glassfish']['install_dir']}/glassfish/bin/asadmin" do
+    mode '0755'
+    owner node['glassfish']['user']
+    group node['glassfish']['group']
+  end
+end
+
 exists_at_run_start = ::File.exist?(node['glassfish']['install_dir'])
 
 template "#{node['glassfish']['install_dir']}/glassfish/config/asenv.conf" do


### PR DESCRIPTION
There is a problem where Chef-client run fails due to node['glassfish']['user'] and node['glassfish']['group'] having insufficient permissions to execute asadmin.

 Errno::EACCES
      -------------
      Permission denied - /usr/local/glassfish/versions/glassfish-5.2022.5/glassfish/bin/asadmin
      
The solution im using now is to grant execution rights to asadmin manually